### PR TITLE
Laravel 5 Upgrades

### DIFF
--- a/src/Publiux/laravelcdn/Commands/EmptyCommand.php
+++ b/src/Publiux/laravelcdn/Commands/EmptyCommand.php
@@ -11,6 +11,7 @@ use Publiux\laravelcdn\Contracts\CdnInterface;
  * @category Command
  *
  * @author   Mahmoud Zalt <mahmoud@vinelab.com>
+ * @author   Raul Ruiz <publiux@gmail.com>
  */
 class EmptyCommand extends Command
 {
@@ -19,7 +20,7 @@ class EmptyCommand extends Command
      *
      * @var string
      */
-    protected $name = 'cdn:empty';
+    protected $signature = 'cdn:empty';
 
     /**
      * The console command description.
@@ -50,32 +51,8 @@ class EmptyCommand extends Command
      *
      * @return mixed
      */
-    public function fire()
+    public function handle()
     {
         $this->cdn->emptyBucket();
-    }
-
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
-    {
-        return [
-//			array('cdn', InputArgument::OPTIONAL, 'cdn option.'),
-        ];
-    }
-
-    /**
-     * Get the console command options.
-     *
-     * @return array
-     */
-    protected function getOptions()
-    {
-        return [
-//			array('example', null, InputOption::VALUE_OPTIONAL, 'An example option.', null),
-        ];
     }
 }

--- a/src/Publiux/laravelcdn/Commands/PushCommand.php
+++ b/src/Publiux/laravelcdn/Commands/PushCommand.php
@@ -11,6 +11,7 @@ use Publiux\laravelcdn\Contracts\CdnInterface;
  * @category Command
  *
  * @author   Mahmoud Zalt <mahmoud@vinelab.com>
+ * @author   Raul Ruiz <publiux@gmail.com>
  */
 class PushCommand extends Command
 {
@@ -19,7 +20,7 @@ class PushCommand extends Command
      *
      * @var string
      */
-    protected $name = 'cdn:push';
+    protected $signature = 'cdn:push';
 
     /**
      * The console command description.
@@ -50,32 +51,8 @@ class PushCommand extends Command
      *
      * @return mixed
      */
-    public function fire()
+    public function handle()
     {
         $this->cdn->push();
-    }
-
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
-    {
-        return [
-//			array('cdn', InputArgument::OPTIONAL, 'cdn option.'),
-        ];
-    }
-
-    /**
-     * Get the console command options.
-     *
-     * @return array
-     */
-    protected function getOptions()
-    {
-        return [
-//			array('example', null, InputOption::VALUE_OPTIONAL, 'An example option.', null),
-        ];
     }
 }

--- a/src/Publiux/laravelcdn/Commands/PushCommand.php
+++ b/src/Publiux/laravelcdn/Commands/PushCommand.php
@@ -20,7 +20,7 @@ class PushCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'cdn:push {--R|review= : Review the files to be uploaded before commencing upload}';
+    protected $signature = 'cdn:push';
 
     /**
      * The console command description.

--- a/src/Publiux/laravelcdn/Commands/PushCommand.php
+++ b/src/Publiux/laravelcdn/Commands/PushCommand.php
@@ -20,7 +20,7 @@ class PushCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'cdn:push';
+    protected $signature = 'cdn:push {--R|review= : Review the files to be uploaded before commencing upload}';
 
     /**
      * The console command description.

--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -194,7 +194,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
         if (count($assets) > 0) {
 
             // Review files before upload if user wishes.
-            $review = $this->console->option('review');
+            /*$review = $this->console->option('review');
             if ($review) {
                 $this->console->writeln('<fg=green>The files to be uploaded are....</fg=green>');
                 foreach ($assets as $file) {
@@ -206,7 +206,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
                     $this->console->writeln('<fg=red>Upload cancelled.</fg=cyan>');
                     return true;
                 }
-            }
+            }*/
 
             $this->console->writeln('<fg=yellow>Upload in progress......</fg=yellow>');
             foreach ($assets as $file) {

--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -311,15 +311,31 @@ class AwsS3Provider extends Provider implements ProviderInterface
         if ($this->getCloudFront() === true) {
             $url = $this->cdn_helper->parseUrl($this->getCloudFrontUrl());
 
-            return $url['scheme'].'://'.$url['host'].'/'.$path;
+            if(array_key_exists('scheme', $url))
+            {
+                return $url['scheme'].'://'.$url['host'].'/'.$path;
+            }
+            else
+            {
+                return '//'.$url['host'].'/'.$path;
+            }
         }
 
         $url = $this->cdn_helper->parseUrl($this->getUrl());
 
         $bucket = $this->getBucket();
         $bucket = (!empty($bucket)) ? $bucket.'.' : '';
+        
+        if(array_key_exists('scheme', $url))
+        {
+            return $url['scheme'].'://'.$bucket.$url['host'].'/'.$path;
+        }
+        else
+        {
+            return '//'.$bucket.$url['host'].'/'.$path;
+        }
 
-        return $url['scheme'].'://'.$bucket.$url['host'].'/'.$path;
+        
     }
 
     /**

--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -192,24 +192,23 @@ class AwsS3Provider extends Provider implements ProviderInterface
 
         // upload each asset file to the CDN
         if (count($assets) > 0) {
-            
+
             // Review files before upload if user wishes.
             $review = $this->console->option('review');
-            if($review)
-            {
+            if ($review) {
                 $this->console->writeln('<fg=green>The files to be uploaded are....</fg=green>');
                 foreach ($assets as $file) {
-                    $this->console->writeln('<fg=cyan>' . $file->getRealpath() . '</fg=cyan>');
+                    $this->console->writeln('<fg=cyan>'.$file->getRealpath().'</fg=cyan>');
                 }
-                
+
                 //Ask the user to confirm that they want to continue the upload.
                 if (!$this->console->confirm('Do you wish to continue? [y|N]')) {
                     $this->console->writeln('<fg=red>Upload cancelled.</fg=cyan>');
+
                     return;
                 }
             }
-            
-            
+
             $this->console->writeln('<fg=yellow>Upload in progress......</fg=yellow>');
             foreach ($assets as $file) {
                 try {

--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -30,6 +30,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
  * @property string  $cloudfront_url
  *
  * @author   Mahmoud Zalt <mahmoud@vinelab.com>
+ * @author   Raul Ruiz <publiux@gmail.com>
  */
 class AwsS3Provider extends Provider implements ProviderInterface
 {
@@ -191,6 +192,24 @@ class AwsS3Provider extends Provider implements ProviderInterface
 
         // upload each asset file to the CDN
         if (count($assets) > 0) {
+            
+            // Review files before upload if user wishes.
+            $review = $this->console->option('review');
+            if($review)
+            {
+                $this->console->writeln('<fg=green>The files to be uploaded are....</fg=green>');
+                foreach ($assets as $file) {
+                    $this->console->writeln('<fg=cyan>' . $file->getRealpath() . '</fg=cyan>');
+                }
+                
+                //Ask the user to confirm that they want to continue the upload.
+                if (!$this->console->confirm('Do you wish to continue? [y|N]')) {
+                    $this->console->writeln('<fg=red>Upload cancelled.</fg=cyan>');
+                    return;
+                }
+            }
+            
+            
             $this->console->writeln('<fg=yellow>Upload in progress......</fg=yellow>');
             foreach ($assets as $file) {
                 try {

--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -204,8 +204,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
                 //Ask the user to confirm that they want to continue the upload.
                 if (!$this->console->confirm('Do you wish to continue? [y|N]')) {
                     $this->console->writeln('<fg=red>Upload cancelled.</fg=cyan>');
-
-                    return;
+                    return true;
                 }
             }
 

--- a/tests/Publiux/laravelcdn/Providers/AwsS3ProviderTest.php
+++ b/tests/Publiux/laravelcdn/Providers/AwsS3ProviderTest.php
@@ -11,6 +11,7 @@ use Mockery as M;
  * @category Test
  *
  * @author   Mahmoud Zalt <mahmoud@vinelab.com>
+ * @author   Raul Ruiz <publiux@gmail.com>
  */
 class AwsS3ProviderTest extends TestCase
 {

--- a/tests/Publiux/laravelcdn/Providers/AwsS3ProviderTest.php
+++ b/tests/Publiux/laravelcdn/Providers/AwsS3ProviderTest.php
@@ -32,9 +32,10 @@ class AwsS3ProviderTest extends TestCase
         $this->m_validator = M::mock('Publiux\laravelcdn\Validators\Contracts\ProviderValidatorInterface');
         $this->m_validator->shouldReceive('validate');
 
-        $this->m_helper = M::mock('Publiux\laravelcdn\CdnHelper');
-        $this->m_helper->shouldReceive('parseUrl')
-                       ->andReturn($this->pased_url);
+        $this->m_helper = new Publiux\laravelcdn\CdnHelper;
+        //$this->m_helper = M::mock('Publiux\laravelcdn\CdnHelper');
+        //$this->m_helper->shouldReceive('parseUrl')
+        //               ->andReturn($this->pased_url);
 
         $this->m_spl_file = M::mock('Symfony\Component\Finder\SplFileInfo');
         $this->m_spl_file->shouldReceive('getPathname')->andReturn('publiux/laravelcdn/tests/Publiux/laravelcdn/AwsS3ProviderTest.php');
@@ -199,9 +200,6 @@ class AwsS3ProviderTest extends TestCase
                 ],
             ],
         ];
-        
-        $this->m_helper->shouldReceive('parseUrl')
-                       ->andReturn($this->cloudfront_url_fullscheme);
 
         $this->p_awsS3Provider->init($configurations);
 

--- a/tests/Publiux/laravelcdn/Providers/AwsS3ProviderTest.php
+++ b/tests/Publiux/laravelcdn/Providers/AwsS3ProviderTest.php
@@ -199,6 +199,9 @@ class AwsS3ProviderTest extends TestCase
                 ],
             ],
         ];
+        
+        $this->m_helper->shouldReceive('parseUrl')
+                       ->andReturn($this->cloudfront_url_fullscheme);
 
         $this->p_awsS3Provider->init($configurations);
 
@@ -234,6 +237,9 @@ class AwsS3ProviderTest extends TestCase
                 ],
             ],
         ];
+        
+        $this->m_helper->shouldReceive('parseUrl')
+                       ->andReturn($this->cloudfront_url_noscheme);
 
         $this->p_awsS3Provider->init($configurations);
 

--- a/tests/Publiux/laravelcdn/Providers/AwsS3ProviderTest.php
+++ b/tests/Publiux/laravelcdn/Providers/AwsS3ProviderTest.php
@@ -69,7 +69,7 @@ class AwsS3ProviderTest extends TestCase
         $this->p_awsS3Provider->shouldReceive('connect')->andReturn(true);
     }
     
-    public function setupCloudfrontFullSchemeTest($fullScheme = false)
+    public function setupCloudfrontTest($fullScheme = false)
     {
         $this->m_helper = new \Publiux\laravelcdn\CdnHelper;
         $this->m_helper = M::mock('Publiux\laravelcdn\CdnHelper');

--- a/tests/Publiux/laravelcdn/Providers/AwsS3ProviderTest.php
+++ b/tests/Publiux/laravelcdn/Providers/AwsS3ProviderTest.php
@@ -37,7 +37,7 @@ class AwsS3ProviderTest extends TestCase
                        ->andReturn($this->pased_url);
 
         $this->m_spl_file = M::mock('Symfony\Component\Finder\SplFileInfo');
-        $this->m_spl_file->shouldReceive('getPathname')->andReturn('vinelab/cdn/tests/Vinelab/Cdn/AwsS3ProviderTest.php');
+        $this->m_spl_file->shouldReceive('getPathname')->andReturn('publiux/laravelcdn/tests/Publiux/laravelcdn/AwsS3ProviderTest.php');
         $this->m_spl_file->shouldReceive('getRealPath')->andReturn(__DIR__.'/AwsS3ProviderTest.php');
 
         $this->p_awsS3Provider = M::mock('\Publiux\laravelcdn\Providers\AwsS3Provider[connect]', 

--- a/tests/Publiux/laravelcdn/Providers/AwsS3ProviderTest.php
+++ b/tests/Publiux/laravelcdn/Providers/AwsS3ProviderTest.php
@@ -52,7 +52,6 @@ class AwsS3ProviderTest extends TestCase
     
     public function setupNonCloudfrontTest()
     {
-        $this->m_helper = new \Publiux\laravelcdn\CdnHelper;
         $this->m_helper = M::mock('Publiux\laravelcdn\CdnHelper');
         $this->m_helper->shouldReceive('parseUrl')
                        ->andReturn(parse_url($this->url));
@@ -71,7 +70,6 @@ class AwsS3ProviderTest extends TestCase
     
     public function setupCloudfrontTest($fullScheme = false)
     {
-        $this->m_helper = new \Publiux\laravelcdn\CdnHelper;
         $this->m_helper = M::mock('Publiux\laravelcdn\CdnHelper');
         
         if($fullScheme)

--- a/tests/Publiux/laravelcdn/Providers/AwsS3ProviderTest.php
+++ b/tests/Publiux/laravelcdn/Providers/AwsS3ProviderTest.php
@@ -32,7 +32,7 @@ class AwsS3ProviderTest extends TestCase
         $this->m_validator = M::mock('Publiux\laravelcdn\Validators\Contracts\ProviderValidatorInterface');
         $this->m_validator->shouldReceive('validate');
 
-        $this->m_helper = new Publiux\laravelcdn\CdnHelper;
+        $this->m_helper = new \Publiux\laravelcdn\CdnHelper;
         //$this->m_helper = M::mock('Publiux\laravelcdn\CdnHelper');
         //$this->m_helper->shouldReceive('parseUrl')
         //               ->andReturn($this->pased_url);


### PR DESCRIPTION
Allows for schemeless URLs for cloudfront, such as //URL or http(s)://URL.

Fixed command handle to use new function handle().
