### PR TITLE
Change Symfony dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         "php": ">=5.5.9",
         "illuminate/support": "~5.0",
         "illuminate/config": "~5.0",
-        "symfony/finder": "2.8.*|3.0.*",
-        "symfony/console": "2.8.*|3.0.*",
+        "symfony/finder": "2.8.*|3.*",
+        "symfony/console": "2.8.*|3.*",
         "aws/aws-sdk-php": "~3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Changing Symfony dependency from 3.0.\* to 3.\* seems to make this package work in Laravel 5.3 without any issues.
