### PR TITLE
Filepath fix

### DIFF
--- a/src/Publiux/laravelcdn/CdnFacade.php
+++ b/src/Publiux/laravelcdn/CdnFacade.php
@@ -109,7 +109,7 @@ class CdnFacade implements CdnFacadeInterface
         // if the package is surpassed, then return the same $path
         // to load the asset from the localhost
         if (isset($this->configurations['bypass']) && $this->configurations['bypass']) {
-            return Request::root().'/'.$path;
+            return Request::root() . '/' . ltrim($path, '/');
         }
 
         if (!isset($path)) {

--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -369,7 +369,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
         if ($this->getCloudFront() === true) {
             $url = $this->cdn_helper->parseUrl($this->getCloudFrontUrl());
 
-            return $url['scheme'] . '://' . $url['host'] . '/' . $path;
+            return $url['scheme'] . '://' . $url['host'] . $url['path'] . $path;
         }
 
         $url = $this->cdn_helper->parseUrl($this->getUrl());


### PR DESCRIPTION
1. Mix had double slashes
2. If my Cloudfront Url is {basePath}/{folder}, only {basePath} is leaving