### PR TITLE
Added FileUploadHandlerInterface to dynamically generate uploadFolder-path

### DIFF
--- a/src/Publiux/laravelcdn/Contracts/FileUploadHandlerInterface.php
+++ b/src/Publiux/laravelcdn/Contracts/FileUploadHandlerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Publiux\laravelcdn\Contracts;
+
+
+interface FileUploadHandlerInterface
+{
+    public function getUploadPathForFile($file);
+}

--- a/src/config/cdn.php
+++ b/src/config/cdn.php
@@ -152,6 +152,7 @@ return [
                 |
                 */
                 'upload_folder' => env('AWS_CDN_ASSET_UPLOAD_FOLDER', ''),
+                'compare_existing_files_by_last_modified' => true,
 
                 /*
                 |--------------------------------------------------------------------------


### PR DESCRIPTION
In order to be more flexible where to store the assets I suggest adding the `FileUploadHandlerInterface` to have a handler is responsible for generating the uploadFolder:

For example:
```
// config.php
'upload_folder' => FileUploadHandler::class,
```

```
class FileUploadHandler implements FileUploadHandlerInterface
{
    public function getUploadPathForFile($file)
    {
        if ($file instanceof \SplFileInfo) {
            $assetFolders = scandir(APPLICATION_PATH . '/public/assets');
            $assetFolders = array_filter($assetFolders, function ($item) {
                return Text::startsWith($item, '.') === false;
            });

            preg_match('/(' . implode('|', $assetFolders) . ')/', $file->getPath(), $matches);

            $subFolder = $matches[1];
            if (!$subFolder) {
                throw new \Exception('Did not find subFolder!');
            }

            return AssetHelper::getCdnUploadFolder($subFolder);
        } else {
            throw new \InvalidArgumentException('Given argument is not a ' . \SplFileInfo::class);
        }
    }
}
```