### PR TITLE
Path style endpoints support for S3 like provider

### DIFF
--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -379,8 +379,17 @@ class AwsS3Provider extends Provider implements ProviderInterface
         $url = $this->cdn_helper->parseUrl($this->getUrl());
 
         $bucket = $this->getBucket();
-        $bucket = (!empty($bucket)) ? $bucket.'.' : '';
 
+        if ($this->supplier['use_path_style_endpoint']) {
+            $bucket = (!empty($bucket)) ? $bucket.'/' : '';
+            $port = (
+                ($url['scheme'] == 'https' && $url['port'] == 443) ||
+                ($url['scheme'] == 'http' && $url['port'] == 80)
+            ) ? '' : ':' . $url['port'];
+            return $url['scheme'] . '://' .  $url['host'] . $port . '/' . $bucket . $path;
+        }
+
+        $bucket = (!empty($bucket)) ? $bucket.'.' : '';
         return $url['scheme'] . '://' . $bucket . $url['host'] . '/' . $path;
     }
 

--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -382,10 +382,14 @@ class AwsS3Provider extends Provider implements ProviderInterface
 
         if ($this->supplier['use_path_style_endpoint']) {
             $bucket = (!empty($bucket)) ? $bucket.'/' : '';
-            $port = (
-                ($url['scheme'] == 'https' && $url['port'] == 443) ||
-                ($url['scheme'] == 'http' && $url['port'] == 80)
-            ) ? '' : ':' . $url['port'];
+            if (isset($url['port'])) {
+                $port = (
+                    ($url['scheme'] == 'https' && $url['port'] == 443) ||
+                    ($url['scheme'] == 'http' && $url['port'] == 80)
+                ) ? '' : ':' . $url['port'];
+            } else {
+                $port = '';
+            }
             return $url['scheme'] . '://' .  $url['host'] . $port . '/' . $bucket . $path;
         }
 

--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -28,6 +28,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
  * @property string  $acl
  * @property string  $cloudfront
  * @property string  $cloudfront_url
+ * @property string  $use_path_style_endpoint
  * @property string $http
  *
  * @author   Mahmoud Zalt <mahmoud@vinelab.com>
@@ -57,6 +58,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
                         'use' => false,
                         'cdn_url' => null,
                     ],
+                    'use_path_style_endpoint' => false
                 ],
             ],
         ],
@@ -141,7 +143,8 @@ class AwsS3Provider extends Provider implements ProviderInterface
             'cloudfront' => $this->default['providers']['aws']['s3']['cloudfront']['use'],
             'cloudfront_url' => $this->default['providers']['aws']['s3']['cloudfront']['cdn_url'],
             'http' => $this->default['providers']['aws']['s3']['http'],
-            'upload_folder' => $this->default['providers']['aws']['s3']['upload_folder']
+            'upload_folder' => $this->default['providers']['aws']['s3']['upload_folder'],
+            'use_path_style_endpoint' => $this->default['providers']['aws']['s3']['use_path_style_endpoint']
         ];
 
         // check if any required configuration is missed
@@ -228,7 +231,8 @@ class AwsS3Provider extends Provider implements ProviderInterface
                         'version' => $this->supplier['version'],
                         'region' => $this->supplier['region'],
                         'endpoint' => $this->supplier['endpoint'],
-                        'http' => $this->supplier['http']
+                        'http' => $this->supplier['http'],
+                        'use_path_style_endpoint' => $this->supplier['use_path_style_endpoint']
                     ]
                 )
             );

--- a/src/config/cdn.php
+++ b/src/config/cdn.php
@@ -111,6 +111,15 @@ return [
                 |
                 */
                 'endpoint' => null,
+                
+                /*
+                 * -----------------------------------------------------------------------
+                 * Use path style endpoint
+                 * -----------------------------------------------------------------------
+                 *
+                 * This can be useful if we use with Minio or similar S3 compatible software
+                 */
+                'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
 
                 /*
                 |--------------------------------------------------------------------------


### PR DESCRIPTION
[Homestead](https://laravel.com/docs/5.7/homestead) [comes](https://laravel.com/docs/5.7/homestead#configuring-minio) with [Minio](https://www.minio.io) and it's S3 compatible provider. However it uses not domain but path style endpoints. This pull request adds support for such endpoints. 

Probably I should have updated tests, however I'm sure how should I write such test. However I have tested this my code and it seems it works.