### PR TITLE
Fix double slash on CDN::mix when bypass is true

### DIFF
--- a/src/Publiux/laravelcdn/CdnFacade.php
+++ b/src/Publiux/laravelcdn/CdnFacade.php
@@ -109,7 +109,7 @@ class CdnFacade implements CdnFacadeInterface
         // if the package is surpassed, then return the same $path
         // to load the asset from the localhost
         if (isset($this->configurations['bypass']) && $this->configurations['bypass']) {
-            return Request::root().'/'.$path;
+            return Request::root().'/'.ltrim($path, '/');
         }
 
         if (!isset($path)) {


### PR DESCRIPTION
This fix the issue #27 