### PR TITLE
Now is possible to set S3 credentials from config file

### DIFF
--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -49,6 +49,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
                     'version' => null,
                     'region' => null,
                     'endpoint' => null,
+                    'credentials' => null,
                     'buckets' => null,
                     'upload_folder' => '',
                     'http' => null,
@@ -56,7 +57,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
                     'cloudfront' => [
                         'use' => false,
                         'cdn_url' => null,
-                    ],
+                    ]
                 ],
             ],
         ],
@@ -135,6 +136,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
             'threshold' => $this->default['threshold'],
             'version' => $this->default['providers']['aws']['s3']['version'],
             'region' => $this->default['providers']['aws']['s3']['region'],
+            'credentials' => $this->default['providers']['aws']['s3']['credentials'],
             'endpoint' => $this->default['providers']['aws']['s3']['endpoint'],
             'buckets' => $this->default['providers']['aws']['s3']['buckets'],
             'acl' => $this->default['providers']['aws']['s3']['acl'],
@@ -216,17 +218,18 @@ class AwsS3Provider extends Provider implements ProviderInterface
 
     /**
      * Create an S3 client instance
-     * (Note: it will read the credentials form the .env file).
      *
      * @return bool
      */
     public function connect()
     {
         try {
+            // Parsing credentials
             // Instantiate an S3 client
             $this->setS3Client(new S3Client([
                         'version' => $this->supplier['version'],
                         'region' => $this->supplier['region'],
+                        'credentials' => $this->supplier['credentials'],
                         'endpoint' => $this->supplier['endpoint'],
                         'http' => $this->supplier['http']
                     ]

--- a/src/config/cdn.php
+++ b/src/config/cdn.php
@@ -63,10 +63,6 @@ return [
     | Of course, examples of configuring each provider platform that is
     | supported by Laravel is shown below to make development simple.
     |
-    | Note: Credentials must be set in the .env file:
-    |         AWS_ACCESS_KEY_ID
-    |         AWS_SECRET_ACCESS_KEY
-    |
     */
     'providers' => [
 
@@ -180,6 +176,21 @@ return [
                 'cloudfront'    => [
                     'use'     => env('CDN_UseCloudFront', false),
                     'cdn_url' => env('CDN_CloudFrontUrl', ''),
+                ],
+
+                /*
+                |--------------------------------------------------------------------------
+                | Credentials for AWS S3 connection
+                |--------------------------------------------------------------------------
+                |
+                | Some AWS credentials are needed for making upload connection to S3 server.
+                | If these config lines commented AWS API tries to read configuration data
+                | from AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.
+                |
+                */
+                'credentials' => [
+                    'key' => env('CDN_AWS_ACCESS_KEY_ID'),
+                    'secret' => env('AWS_SECRET_ACCESS_KEY')
                 ],
 
                 /*


### PR DESCRIPTION
Works as title says. Otherwise old lookup method from environment variables will be used.

Sometimes projects uses multiple S3 compatible providers and than they have a problem because there are no ways to rename env variables. With this pull request it should be possible to rename variable as user needs.

Maybe tests could be useful for this case but I'm not sure how to correct write one. So, again for this pull request, sorry for they are missing.