### PR TITLE
Added HTTP Compression support for uploaded files

### DIFF
--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -190,7 +190,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
                 try {
                     $needsCompression = $this->needCompress($file);
                     $this->console->writeln(
-                        '<fg=magenta>' . str_pad( number_format (($count / ($i + 1) ) * 100, 2), 6, ' ',STR_PAD_LEFT) . '% </fg=magenta>' .
+                        '<fg=magenta>' . str_pad( number_format (100 / $count * ($i + 1), 2), 6, ' ',STR_PAD_LEFT) . '% </fg=magenta>' .
                         '<fg=cyan>Uploading file path: ' . $file->getRealpath() . '</fg=cyan>' .
                         ($needsCompression ? ' <fg=green>Compressed</fg=green>' : '')
                     );

--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -208,7 +208,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
                         'CacheControl' => $this->default['providers']['aws']['s3']['cache-control'],
                         'Metadata' => $this->default['providers']['aws']['s3']['metadata'],
                         'Expires' => $this->default['providers']['aws']['s3']['expires'],
-                        'ContentType' => File::mimeType($file->getRealPath()),
+                        'ContentType' => $this->getMimetype($file),
                         'ContentEncoding' => $needsCompression ? $this->compression['algorithm'] : 'identity',
                     ]);
 //                var_dump(get_class($command));exit();
@@ -480,4 +480,20 @@ class AwsS3Provider extends Provider implements ProviderInterface
         }
         return fopen($file->getRealPath(), 'r');
     }
+
+    /**
+     * Get mimetype from config or from system
+     *
+     * @param SplFileInfo $file File info to get mimetype
+     *
+     * @return false|string
+     */
+    protected function getMimetype(SplFileInfo $file) {
+        $ext = '.' . $file->getExtension();
+        if (is_array($this->compression['mimetypes']) && isset($this->compression['mimetypes'][$ext])) {
+            return $this->compression['mimetypes'][$ext];
+        }
+        return File::mimeType($file->getRealPath());
+    }
+
 }

--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -190,13 +190,14 @@ class AwsS3Provider extends Provider implements ProviderInterface
         $count = count($assets);
         if ($count > 0) {
             $this->console->writeln('<fg=yellow>Upload in progress......</fg=yellow>');
-            foreach ($assets as $i => $file) {
+            $o = 0;
+            foreach ($assets as $file) {
                 try {
                     $needsCompression = $this->needCompress($file);
                     $this->console->writeln(
-                        '<fg=magenta>' . str_pad( number_format (100 / $count * ($i + 1), 2), 6, ' ',STR_PAD_LEFT) . '% </fg=magenta>' .
+                        '<fg=magenta>' . str_pad( number_format (100 / $count * ++$o, 2), 6, ' ',STR_PAD_LEFT) . '% </fg=magenta>' .
                         '<fg=cyan>Uploading file path: ' . $file->getRealpath() . '</fg=cyan>' .
-                        ($needsCompression ? ' <fg=green>Compressed</fg=green>' : '')
+                        ($needsCompression ? PHP_EOL. "        <fg=green>Compressed</fg=green>" : '')
                     );
                     $command = $this->s3_client->getCommand('putObject', [
 

--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -32,6 +32,7 @@ use Symfony\Component\Finder\SplFileInfo;
  * @property string  $cloudfront_url
  * @property string $http
  * @property array  $compression
+ * @property array  $mimetypes
  *
  * @author   Mahmoud Zalt <mahmoud@vinelab.com>
  */
@@ -50,6 +51,8 @@ class AwsS3Provider extends Provider implements ProviderInterface
             'extensions' => [],
             'algorithm' => null,
             'level' => 9
+        ],
+        'mimetypes' => [
         ],
         'providers' => [
             'aws' => [
@@ -75,7 +78,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
      *
      * @var array
      */
-    protected $rules = ['version', 'region', 'key', 'secret', 'buckets', 'url'];
+    protected $rules = ['version', 'region', 'key', 'secret', 'buckets', 'url', 'mimetypes'];
 
     /**
      * this array holds the parsed configuration to be used across the class.
@@ -151,6 +154,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
             'http' => $this->default['providers']['aws']['s3']['http'],
             'upload_folder' => $this->default['providers']['aws']['s3']['upload_folder'],
             'compression' => $this->default['compression'],
+            'mimetypes' => $this->default['mimetypes'],
         ];
 
         // check if any required configuration is missed
@@ -490,8 +494,8 @@ class AwsS3Provider extends Provider implements ProviderInterface
      */
     protected function getMimetype(SplFileInfo $file) {
         $ext = '.' . $file->getExtension();
-        if (is_array($this->compression['mimetypes']) && isset($this->compression['mimetypes'][$ext])) {
-            return $this->compression['mimetypes'][$ext];
+        if (isset($this->mimetypes[$ext])) {
+            return $this->mimetypes[$ext];
         }
         return File::mimeType($file->getRealPath());
     }

--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -186,12 +186,11 @@ class AwsS3Provider extends Provider implements ProviderInterface
         $count = count($assets);
         if ($count > 0) {
             $this->console->writeln('<fg=yellow>Upload in progress......</fg=yellow>');
-            $count--;
             foreach ($assets as $i => $file) {
                 try {
                     $needsCompression = $this->needCompress($file);
                     $this->console->writeln(
-                        '<fg=magenta>' . str_pad( number_format (100 / $count * $i, 2), 6, ' ',STR_PAD_LEFT) . '% </fg=magenta>' .
+                        '<fg=magenta>' . str_pad( number_format (($count / ($i + 1) ) * 100, 2), 6, ' ',STR_PAD_LEFT) . '% </fg=magenta>' .
                         '<fg=cyan>Uploading file path: ' . $file->getRealpath() . '</fg=cyan>' .
                         ($needsCompression ? ' <fg=green>Compressed</fg=green>' : '')
                     );

--- a/src/config/cdn.php
+++ b/src/config/cdn.php
@@ -253,4 +253,39 @@ return [
         'hidden'      => true,
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | File compression
+    |--------------------------------------------------------------------------
+    |
+    | Here is possible to specify files that should be compressed before uploading.
+    |
+    | S3 like services needs this to deliver content faster, because these services
+    | in most cases doesn't have build'in compression.
+    |
+    | Extensions defines what file extensions should be compressed. All of them needs to
+    | begin with a dot.
+    |
+    | Algorithm defines how to compress file. At current moment only 'gzip' and 'deflate'
+    | are supported. null value means that no compression should be used.
+    |
+    | Level defines how much data should be compressed used when compressing files.
+    | -1 means that default compression level should be used. Min - 0, max - 9.
+    |
+    */
+    'compression' => [
+        'extensions' => [
+            '.js',
+            '.css',
+            '.xml',
+            '.svg',
+            '.html',
+            '.htm',
+            '.txt',
+            '.md'
+        ],
+        'algorithm' => 'gzip',
+        'level' => 9
+    ],
+
 ];

--- a/src/config/cdn.php
+++ b/src/config/cdn.php
@@ -255,6 +255,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Forced mimetypes by file extensions
+    |--------------------------------------------------------------------------
+    |
+    | Mimetypes are collection with file extensions as key and mimetypes as values. It used
+    | when we need to force that some extensions should have some special file types otherwise
+    | OS detected mimetypes will be used.
+    |
+    */
+    'mimetypes' => [
+        '.css' => 'text/css'
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | File compression
     |--------------------------------------------------------------------------
     |
@@ -272,10 +286,6 @@ return [
     | Level defines how much data should be compressed used when compressing files.
     | -1 means that default compression level should be used. Min - 0, max - 9.
     |
-    | Mimetypes are collection with file extensions as key and mimetypes as values. It used
-    | when we need to force that some extensions should have some special file types otherwise
-    | OS detected mimetypes will be used.
-    |
     */
     'compression' => [
         'extensions' => [
@@ -289,10 +299,7 @@ return [
             '.md'
         ],
         'algorithm' => 'gzip',
-        'level' => 9,
-        'mimetypes' => [
-            '.css' => 'text/css'
-        ]
+        'level' => 9
     ],
 
 ];

--- a/src/config/cdn.php
+++ b/src/config/cdn.php
@@ -272,6 +272,10 @@ return [
     | Level defines how much data should be compressed used when compressing files.
     | -1 means that default compression level should be used. Min - 0, max - 9.
     |
+    | Mimetypes are collection with file extensions as key and mimetypes as values. It used
+    | when we need to force that some extensions should have some special file types otherwise
+    | OS detected mimetypes will be used.
+    |
     */
     'compression' => [
         'extensions' => [
@@ -285,7 +289,10 @@ return [
             '.md'
         ],
         'algorithm' => 'gzip',
-        'level' => 9
+        'level' => 9,
+        'mimetypes' => [
+            '.css' => 'text/css'
+        ]
     ],
 
 ];


### PR DESCRIPTION
Based on https://stackoverflow.com/questions/31801661/gzip-compression-on-static-amazon-s3-files recommendations this ticket adds possibility to specify files that must be compressed before uploading to S3. This let's faster to serve static files.

Again, sorry for missing tests. I'm still not good with them :|