### PR TITLE
Bugfix search for files in folders

### DIFF
--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -277,6 +277,10 @@ class AwsS3Provider extends Provider implements ProviderInterface
         $assets->transform(function ($item, $key) use (&$filesOnAWS) {
             $fileOnAWS = $filesOnAWS->get(str_replace('\\', '/', $this->upload_folder.$item->getPathName()));
 
+            if (!$fileOnAWS) {
+                return $item;
+            }
+            
             //select to upload files that are different in size AND last modified time.
             if (!($item->getMTime() > (int) $fileOnAWS['LastModified']) || !($item->getSize() === (int) $fileOnAWS['Size'])) {
                 return $item;

--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -280,9 +280,9 @@ class AwsS3Provider extends Provider implements ProviderInterface
             if (!$fileOnAWS) {
                 return $item;
             }
-            
+
             //select to upload files that are different in size AND last modified time.
-            if (!($item->getMTime() > (int) $fileOnAWS['LastModified']) || !($item->getSize() === (int) $fileOnAWS['Size'])) {
+            if ($item->getMTime() > (int) $fileOnAWS['LastModified'] || !($item->getSize() === (int) $fileOnAWS['Size'])) {
                 return $item;
             }
         });

--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -275,7 +275,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
         }
 
         $assets->transform(function ($item, $key) use (&$filesOnAWS) {
-            $fileOnAWS = $filesOnAWS->get(str_replace('\\', '/', $item->getPathName()));
+            $fileOnAWS = $filesOnAWS->get(str_replace('\\', '/', $this->upload_folder.$item->getPathName()));
 
             //select to upload files that are different in size AND last modified time.
             if (!($item->getMTime() === $fileOnAWS['LastModified']) && !($item->getSize() === $fileOnAWS['Size'])) {

--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -278,7 +278,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
             $fileOnAWS = $filesOnAWS->get(str_replace('\\', '/', $this->upload_folder.$item->getPathName()));
 
             //select to upload files that are different in size AND last modified time.
-            if (!($item->getMTime() === $fileOnAWS['LastModified']) && !($item->getSize() === $fileOnAWS['Size'])) {
+            if (!($item->getMTime() > (int) $fileOnAWS['LastModified']) || !($item->getSize() === (int) $fileOnAWS['Size'])) {
                 return $item;
             }
         });


### PR DESCRIPTION
I have encountered an issue while using DigitalOcean Spaces. Right now, method is not searching for files that could be placed inside the folder. This should fix that.

I don't know how it looks when AWS S3 is used, but DO Spaces return some values as a string, so I've decided to cast them as an integer now. In Spaces, "LastModified" is a timestamp of when the file has been uploaded, so it will always be a false check. I've changed the comparison to look for a newer file on local disk.