### PR TITLE
Replaced listObjects with listObjectsV2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,54 +1,55 @@
 {
-    "name": "publiux/laravelcdn",
+    "name": "khoubeib/laravelcdn",
     "description": "Content Delivery Network (CDN) Package for Laravel",
+    "type": "library",
     "license": "MIT",
     "keywords": [
-      "laravel",
-      "CDN",
-      "upload",
-      "AWS",
-      "S3",
-      "AWS S3",
-      "amazon",
-      "Assets Upload",
-      "Content Delivery Network"
-    ],
-    "authors": [
-        {
-            "name": "Raul Ruiz",
-            "email": "publiux@gmail.com"
-        }
+        "laravel",
+        "CDN",
+        "upload",
+        "AWS",
+        "S3",
+        "AWS S3",
+        "amazon",
+        "Assets Upload",
+        "Content Delivery Network"
     ],
     "require": {
         "php": ">=5.5.9",
-      "illuminate/support": "^8",
-      "illuminate/config": "^8",
-      "symfony/finder": "^5",
-      "symfony/console": "^5",
-      "aws/aws-sdk-php": "~3.0"
+        "illuminate/support": "^8",
+        "illuminate/config": "^8",
+        "symfony/finder": "^5",
+        "symfony/console": "^5",
+        "aws/aws-sdk-php": "~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "mockery/mockery": "1.4.2"
     },
+    "authors": [
+        {
+            "name": "Khoubeib Bouthour",
+            "email": "khoubeibouthour@gmail.com"
+        }
+    ],
     "autoload": {
         "classmap": [
             "tests/TestCase.php",
             "src/Publiux/laravelcdn/Exceptions"
         ],
-      "psr-0": {
+        "psr-0": {
             "Publiux\\laravelcdn\\": "src/"
         }
     },
-  "extra": {
-    "laravel": {
-      "providers": [
-        "Publiux\\laravelcdn\\CdnServiceProvider"
-      ],
-      "aliases": {
-        "CDN": "Publiux\\laravelcdn\\Facades\\CdnFacadeAccessor"
-      }
-    }
-  },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Publiux\\laravelcdn\\CdnServiceProvider"
+            ],
+            "aliases": {
+                "CDN": "Publiux\\laravelcdn\\Facades\\CdnFacadeAccessor"
+            }
+        }
+    },
     "minimum-stability": "stable"
 }


### PR DESCRIPTION
S3 `listObjects` endpoint returns up to a maximum of 1,000 objects without pagination. This has been revisited in its new version `listObjectsV2`