### PR TITLE
fix: null value for foreach files from s3

### DIFF
--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -260,7 +260,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
             $files = $this->s3_client->listObjectsV2($params);
             $params['ContinuationToken'] = $files->get('NextContinuationToken');
 
-            foreach ($files->get('Contents') as $file) {
+            foreach ($files->get('Contents')?:[] as $file) {
                 $a = [
                     'Key' => $file['Key'],
                     "LastModified" => $file['LastModified']->getTimestamp(),

--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -279,7 +279,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
             $fileOnAWS = $filesOnAWS->get(str_replace('\\', '/', $file->getPathName()));
 
             //select to upload files that are different in size AND last modified time.
-            return $fileOnAWS && $file->getMTime() !== $fileOnAWS['LastModified'] && $file->getSize() !== $fileOnAWS['Size'];
+            return !$fileOnAWS || $file->getMTime() !== $fileOnAWS['LastModified'] && $file->getSize() !== $fileOnAWS['Size'];
         });
     }
 

--- a/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
+++ b/src/Publiux/laravelcdn/Providers/AwsS3Provider.php
@@ -279,7 +279,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
             $fileOnAWS = $filesOnAWS->get(str_replace('\\', '/', $file->getPathName()));
 
             //select to upload files that are different in size AND last modified time.
-            return $file->getMTime() !== $fileOnAWS['LastModified'] && $file->getSize() !== $fileOnAWS['Size'];
+            return $fileOnAWS && $file->getMTime() !== $fileOnAWS['LastModified'] && $file->getSize() !== $fileOnAWS['Size'];
         });
     }
 


### PR DESCRIPTION
**Description**
This pull request addresses an issue where `$files->get('Contents')` returns `null`, causing an error to be thrown when running `php artisan cdn:push`. The bug has been fixed, and this PR includes the necessary changes to resolve the issue.

Thank you for your attention to this bug fix. Please review and merge this PR at your earliest convenience.
